### PR TITLE
Support for pattern bindings.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -32,6 +32,14 @@ Executable "parsing"
   ByteOpt+:         -ppx src/ppx_monad.byte
   NativeOpt+:       -ppx src/ppx_monad.byte
 
+Executable "patterns"
+  Path:             examples/
+  MainIs:           patterns.ml
+  BuildTools:       ocamlbuild
+  BuildDepends:     compiler-libs, compiler-libs.common
+  ByteOpt+:         -ppx src/ppx_monad.byte
+  NativeOpt+:       -ppx src/ppx_monad.byte
+
 SourceRepository master
   Type:     git
   Location: git://github.com/danmey/ppx-monad.git

--- a/_oasis
+++ b/_oasis
@@ -24,6 +24,14 @@ Executable "basics"
   ByteOpt+:         -ppx src/ppx_monad.byte
   NativeOpt+:       -ppx src/ppx_monad.byte
 
+Executable "parsing"
+  Path:             examples/
+  MainIs:           parsing.ml
+  BuildTools:       ocamlbuild
+  BuildDepends:     compiler-libs, compiler-libs.common
+  ByteOpt+:         -ppx src/ppx_monad.byte
+  NativeOpt+:       -ppx src/ppx_monad.byte
+
 SourceRepository master
   Type:     git
   Location: git://github.com/danmey/ppx-monad.git

--- a/examples/basics.ml
+++ b/examples/basics.ml
@@ -10,7 +10,7 @@ module Exception = struct
   let fail str = Exception str
 
   let bind x f = match x with
-  | Exception str -> x
+  | Exception str as e -> e
   | Continue x -> f x
 
   let run = function

--- a/examples/parsing.ml
+++ b/examples/parsing.ml
@@ -1,0 +1,141 @@
+(* A fairly direct translation of "Monadic Parsing in Haskell" (Graham Hutton
+   & Erik Meijer) *)
+
+type 'a parser_ = Parser of (char list -> ('a * char list) list)
+
+let parse (Parser p) = p
+
+let explode s =
+  let l = ref [] in
+  begin
+    String.iter (fun c -> l := c :: !l) s;
+    List.rev !l
+  end
+
+let implode s = String.concat "" (List.map (String.make 1) s)
+    
+module ListMonad = struct
+  type 'a t = 'a list
+
+  let return x = [x]
+  let bind m k = List.concat (List.map k m)
+  let fail _ = []
+end
+module Parser =
+struct
+  type 'a t = 'a parser_
+
+  let return a = Parser (fun cs -> [(a, cs)])
+
+  let bind p f = Parser (fun cs -> List.concat 
+    ListMonad.(perform
+                 ((a, cs') <-- parse p cs;
+                  return (parse (f a) cs'))))
+
+  let zero = Parser (fun cs -> [])
+
+  let (++) p q = Parser (fun cs -> parse p cs @ parse q cs)
+
+  let item : char parser_ =
+    Parser (function
+             []    -> []
+           | c::cs -> [(c, cs)])
+      
+  let (+++) p q = Parser (fun cs ->
+                             match parse (p ++ q) cs with
+                              | []    -> []
+                              | x::xs -> [x])
+
+  let sat : (char -> bool) -> char parser_ =
+    fun p -> perform (c <-- item;
+                      if p c then return c
+                      else zero)
+
+  let char : char -> char parser_
+    = fun c -> sat ((=)c)
+
+  let string : string -> string parser_
+    = let rec char_list : char list -> char list parser_ = function
+      | []    -> return []
+      | c::cs -> perform (char c;
+                          char_list cs;
+                          return (c::cs))
+      in fun s -> perform (cl <-- char_list (explode s);
+                           return (implode cl))
+
+  let rec many : 'a. 'a parser_ -> 'a list parser_
+    = fun p -> many1 p +++ return []
+
+  and many1 : 'a. 'a parser_ -> 'a list parser_
+    = fun p -> perform (x <-- p; xs <-- many p; return (x::xs))
+
+  let rec sepby : 'a 'b. 'a parser_ -> 'b parser_ -> 'a list parser_
+    = fun p sep -> (sepby1 p sep) +++ return []
+
+  and sepby1 : 'a 'b. 'a parser_ -> 'b parser_ -> 'a list parser_
+    = fun p sep -> perform (x <-- p;
+			    xs <-- many (perform (sep; p));
+			    return (x::xs))
+
+  let rec chainl : 'a. 'a parser_ -> ('a -> 'a -> 'a) parser_ -> 'a -> 'a parser_
+    = fun p op a -> chainl1 p op +++ return a
+
+  and chainl1 : 'a. 'a parser_ -> ('a -> 'a -> 'a) parser_ -> 'a parser_
+    = fun p op -> 
+      let rec rest a = perform (f <-- op;
+				b <-- p;
+				rest (f a b))
+	+++ return a
+      in
+      perform (a <-- p; rest a)
+
+  let is_space c = List.mem c [' '; '\t'; '\n'; '\r']
+  let space : string parser_ = perform (cs <-- many (sat is_space); return (implode cs))
+
+  let token : 'a. 'a parser_ -> 'a parser_
+    = fun p -> perform (a <-- p;
+			space;
+			return a)
+
+  let symb : string -> string parser_
+    = fun cs -> token (string cs)
+
+  let apply : 'a. 'a parser_ -> string -> ('a * string) list
+    = fun p s -> ListLabels.map (parse (perform (space; p)) (explode s))
+      ~f:(fun (x, s) -> (x, implode s))
+end
+
+open Parser
+
+let is_digit c = List.mem c ['0'; '1'; '2'; '3'; '4'; '5'; '6'; '7'; '8'; '9']
+
+let digit = perform (x <-- token (sat is_digit);
+		     return (Char.code x - Char.code '0'))
+
+let mulop = (perform (symb "*";
+		      return ( * ))
+	     +++ 
+	     perform (symb "/";
+		      return ( / )))
+
+let addop = (perform (symb "+";
+		      return ( + ))
+	     +++ 
+	     perform (symb "-";
+		      return ( - )))
+
+let rec factor' = lazy (digit +++ perform (symb "(";
+	                                   n <-- Lazy.force expr';
+		                           symb ")";
+ 		                           return n))
+
+and term' = lazy (chainl1 (Lazy.force factor') mulop)
+
+and expr' = lazy (chainl1 (Lazy.force term') addop)
+
+let factor, term, expr = Lazy.force factor', Lazy.force term', Lazy.force expr'
+
+let () = begin
+  assert ((apply expr " 1 - 2 * 3 + 4 ") = [(-1, "")]);
+  print_endline "Parsing succeeded"
+end

--- a/examples/parsing.ml
+++ b/examples/parsing.ml
@@ -74,8 +74,8 @@ struct
 
   and sepby1 : 'a 'b. 'a parser_ -> 'b parser_ -> 'a list parser_
     = fun p sep -> perform (x <-- p;
-			    xs <-- many (perform (sep; p));
-			    return (x::xs))
+                            xs <-- many (perform (sep; p));
+                            return (x::xs))
 
   let rec chainl : 'a. 'a parser_ -> ('a -> 'a -> 'a) parser_ -> 'a -> 'a parser_
     = fun p op a -> chainl1 p op +++ return a
@@ -83,9 +83,9 @@ struct
   and chainl1 : 'a. 'a parser_ -> ('a -> 'a -> 'a) parser_ -> 'a parser_
     = fun p op -> 
       let rec rest a = perform (f <-- op;
-				b <-- p;
-				rest (f a b))
-	+++ return a
+                                b <-- p;
+                                rest (f a b))
+        +++ return a
       in
       perform (a <-- p; rest a)
 
@@ -94,8 +94,8 @@ struct
 
   let token : 'a. 'a parser_ -> 'a parser_
     = fun p -> perform (a <-- p;
-			space;
-			return a)
+                        space;
+                        return a)
 
   let symb : string -> string parser_
     = fun cs -> token (string cs)
@@ -110,24 +110,24 @@ open Parser
 let is_digit c = List.mem c ['0'; '1'; '2'; '3'; '4'; '5'; '6'; '7'; '8'; '9']
 
 let digit = perform (x <-- token (sat is_digit);
-		     return (Char.code x - Char.code '0'))
+                     return (Char.code x - Char.code '0'))
 
 let mulop = (perform (symb "*";
-		      return ( * ))
-	     +++ 
-	     perform (symb "/";
-		      return ( / )))
+                      return ( * ))
+             +++ 
+             perform (symb "/";
+                      return ( / )))
 
 let addop = (perform (symb "+";
-		      return ( + ))
-	     +++ 
-	     perform (symb "-";
-		      return ( - )))
+                      return ( + ))
+             +++ 
+             perform (symb "-";
+                      return ( - )))
 
 let rec factor' = lazy (digit +++ perform (symb "(";
-	                                   n <-- Lazy.force expr';
-		                           symb ")";
- 		                           return n))
+                                           n <-- Lazy.force expr';
+                                           symb ")";
+                                           return n))
 
 and term' = lazy (chainl1 (Lazy.force factor') mulop)
 

--- a/examples/patterns.ml
+++ b/examples/patterns.ml
@@ -8,23 +8,23 @@ end
 
 let tests () = ListMonad.(begin
   let vs = perform (`A x <-- [`A 1; `B '2'; `C true; `A 4; `A 5; `B '6'];
-		    return (x * 2)) in
+                    return (x * 2)) in
     assert (vs = [2; 8; 10]);
 
   let vs = perform (`A x <-- [`A 1; `B '2'; `C true; `A 4; `A 5; `B '6'];
-		    (y, Some z) <-- [(1, None); (2, Some 3); (4, Some 5)];
-		    return (x + y + z)) in
+                    (y, Some z) <-- [(1, None); (2, Some 3); (4, Some 5)];
+                    return (x + y + z)) in
     assert (vs = [1 + 2 + 3;
-		  1 + 4 + 5;
-		  4 + 2 + 3;
-		  4 + 4 + 5;
-		  5 + 2 + 3;
-		  5 + 4 + 5]);
+                  1 + 4 + 5;
+                  4 + 2 + 3;
+                  4 + 4 + 5;
+                  5 + 2 + 3;
+                  5 + 4 + 5]);
 
   let vs = perform ([|x; y|] <-- [[|1; 2|]; [||]; [|3; 4; 5|]; [|6; 7|]];
-		    return (x + y)) in
+                    return (x + y)) in
     assert (vs = [1 + 2;
-		  6 + 7]);
+                  6 + 7]);
 end)
 
 let () = begin

--- a/examples/patterns.ml
+++ b/examples/patterns.ml
@@ -1,0 +1,33 @@
+module ListMonad = struct
+  type 'a t = 'a list
+
+  let return x = [x]
+  let bind m k = List.concat (List.map k m)
+  let fail _ = []
+end
+
+let tests () = ListMonad.(begin
+  let vs = perform (`A x <-- [`A 1; `B '2'; `C true; `A 4; `A 5; `B '6'];
+		    return (x * 2)) in
+    assert (vs = [2; 8; 10]);
+
+  let vs = perform (`A x <-- [`A 1; `B '2'; `C true; `A 4; `A 5; `B '6'];
+		    (y, Some z) <-- [(1, None); (2, Some 3); (4, Some 5)];
+		    return (x + y + z)) in
+    assert (vs = [1 + 2 + 3;
+		  1 + 4 + 5;
+		  4 + 2 + 3;
+		  4 + 4 + 5;
+		  5 + 2 + 3;
+		  5 + 4 + 5]);
+
+  let vs = perform ([|x; y|] <-- [[|1; 2|]; [||]; [|3; 4; 5|]; [|6; 7|]];
+		    return (x + y)) in
+    assert (vs = [1 + 2;
+		  6 + 7]);
+end)
+
+let () = begin
+  tests ();
+  print_endline "Pattern-matching tests passed."
+end

--- a/src/ppx_monad.ml
+++ b/src/ppx_monad.ml
@@ -39,6 +39,33 @@ open Longident
 
 let fail_exit_code = ref 0
 
+exception Pattern_translation_failure of Location.t
+
+let map_opt f = function
+    None -> None
+  | Some e -> Some (f e)
+
+let rec patt_of_expr : expression -> pattern = 
+  fun {pexp_desc; pexp_loc} ->
+    let desc = match pexp_desc with
+      | Pexp_ident {txt = Lident txt; loc} -> Ppat_var { txt; loc }
+      | Pexp_constant c -> Ppat_constant c
+      | Pexp_tuple es -> Ppat_tuple (List.map patt_of_expr es)
+      | Pexp_record (fields, basis) ->
+        Ppat_record (List.map (fun (f, e) -> f, patt_of_expr e) fields, Open)
+      | Pexp_construct (ident, e_opt, flag) ->
+        Ppat_construct (ident, map_opt patt_of_expr e_opt, flag)
+      | Pexp_variant (label, e_opt) ->
+        Ppat_variant (label, map_opt patt_of_expr e_opt)
+      | Pexp_array es -> Ppat_array (List.map patt_of_expr es)
+      | Pexp_constraint (e, Some t, None) ->
+        Ppat_constraint (patt_of_expr e, t)
+      | Pexp_lazy e -> Ppat_lazy (patt_of_expr e)
+      (* There's no expression syntax corresponding to _-, as-, or- or #-
+         patterns. *)
+      | _ -> raise (Pattern_translation_failure pexp_loc)
+    in { ppat_desc = desc; ppat_loc = pexp_loc }
+
 let mapper =
   object(this)
 
@@ -60,17 +87,16 @@ let mapper =
             next)
           when in_monad ->
 
-        begin match lhs.pexp_desc with
-        | Pexp_ident { txt = Lident nm } ->
+        let patt =
+          try patt_of_expr lhs 
+          with Pattern_translation_failure loc ->
+            Format.eprintf "%appx-monad: Invalid pattern.@." Location.print loc;
+            exit !fail_exit_code
+        in
           E.apply_nolabs (E.lid "bind")
             [ this # expr rhs;
               E.function_ "" None
-                [ P.var (Location.mkloc nm Location.none), this # expr next ] ]
-
-        | _ ->
-          Format.eprintf "%appx-monad: Expected variable binding.@." Location.print lhs.pexp_loc;
-          exit !fail_exit_code
-        end
+                [ patt, this # expr next ] ]
 
       | Pexp_sequence (first, second) when in_monad ->
         E.apply_nolabs (E.lid "bind")

--- a/src/ppx_monad.ml
+++ b/src/ppx_monad.ml
@@ -39,8 +39,6 @@ open Longident
 
 let fail_exit_code = ref 0
 
-let gensym = let count = ref 0 in fun () -> incr count; Printf.sprintf "__ppx_monad_%.2d" !count
-
 let mapper =
   object(this)
 

--- a/src/ppx_monad.ml
+++ b/src/ppx_monad.ml
@@ -45,6 +45,73 @@ let map_opt f = function
     None -> None
   | Some e -> Some (f e)
 
+module Exhaustive =
+struct
+  (*
+    Sometimes we can detect that a pattern p is 'exhaustive' -- i.e. that
+    'function p -> () | _ -> ()' will cause a redundancy warning.  For
+    example, variables are exhaustive, as are tuples of exhaustive patterns.
+
+    In other cases we can detect that a pattern p is 'inexhaustive' --
+    i.e. that 'function p -> () | _ -> ()' will not cause a redundancy
+    warning.  For example, integer constants are inexhaustive, as are array
+    patterns.
+
+    In a third family of cases we cannot detect syntactically whether a
+    pattern p is exhaustive or inexhaustive because we do not have access to
+    enough information.  For example, whether a pattern constisting of a
+    constructor C is exhaustive or inexhaustive depends on whether it is the
+    only constructor for the datatype, and whether a polymorphic variant
+    pattern with a type ascription (`C:t) is exhaustive depends on the
+    definition of the type t.
+
+    [Technical note: we base the definition of 'exhaustive' on redundancy
+     warnings rather than exhaustiveness warnings to give the right behaviour
+     for polymorphic variants.  Note that
+
+        function `A -> ()
+
+     does not cause an exhaustiveness warning (and so `A could be considered
+     exhaustive), but
+
+       function `A -> () | _ -> ()
+
+     does not cause a redundancy warning (and so `A could be considered
+     inexhaustive).  However, the input to the first function has type [< `A]
+     rather than the more liberal type [> `A].  We want the more liberal type,
+     which allows us to accept a  larger class of programs.]
+  *)
+
+  type t = Exhaustive | Inexhaustive | PossiblyExhaustive
+
+  let (&&) l r = match l, r with
+    | Exhaustive, e | e, Exhaustive -> e
+    | Inexhaustive, e | e, Inexhaustive -> Inexhaustive
+    | PossiblyExhaustive, PossiblyExhaustive -> PossiblyExhaustive
+
+  let all p = List.fold_left (fun e x -> e && p x) PossiblyExhaustive
+
+  let rec is_exhaustive : pattern -> t =
+    fun {ppat_desc} -> match ppat_desc with
+      | Ppat_any
+      | Ppat_var _
+      | Ppat_unpack _ -> Exhaustive
+      | Ppat_tuple ps -> all is_exhaustive ps
+      | Ppat_alias (p, _)
+      | Ppat_lazy p -> is_exhaustive p
+      (* We can't tell whether (`A:t) is exhaustive without resolving t *)
+      | Ppat_constraint (p, _) -> PossiblyExhaustive
+      | Ppat_array _
+      (* 'Constant' means integer, string or character constant. *)
+      | Ppat_constant _ -> Inexhaustive
+      | Ppat_type _
+      | Ppat_variant _
+      | Ppat_construct _ -> PossiblyExhaustive
+      (* 'Or'-patterns are too much work for the moment *)
+      | Ppat_or _ -> PossiblyExhaustive
+      | Ppat_record (fields, _) -> all (fun (_,p) -> is_exhaustive p) fields
+end
+
 let rec patt_of_expr : expression -> pattern = 
   fun {pexp_desc; pexp_loc} ->
     let desc = match pexp_desc with
@@ -87,16 +154,61 @@ let mapper =
             next)
           when in_monad ->
 
-        let patt =
-          try patt_of_expr lhs 
-          with Pattern_translation_failure loc ->
-            Format.eprintf "%appx-monad: Invalid pattern.@." Location.print loc;
-            exit !fail_exit_code
-        in
-          E.apply_nolabs (E.lid "bind")
-            [ this # expr rhs;
-              E.function_ "" None
-                [ patt, this # expr next ] ]
+          let patt =
+            try patt_of_expr lhs 
+            with Pattern_translation_failure loc ->
+              Format.eprintf "%appx-monad: Invalid pattern.@." Location.print loc;
+              exit !fail_exit_code
+          in
+          let fail_code = E.apply_nolabs (E.lid "fail")
+            [E.constant (Const_string ("Pattern-match failure in perform-block"))]
+          in
+          Exhaustive.(match is_exhaustive patt with
+            | Exhaustive ->
+            (* We've determined that pattern-matching against p cannot fail.
+               The desugaring is
+               
+               p <-- e1; e2    ~>    bind e1 (fun p -> e2)
+            *)
+              E.apply_nolabs (E.lid "bind")
+                [ this # expr rhs;
+                  E.function_ "" None [ patt, this # expr next ] ]
+            | Inexhaustive ->
+            (* We've determined that pattern-matching against p can fail.
+               The desugaring is
+               
+               p <-- e1; e2    ~>    bind e1 (function p -> e2
+               | _ -> fail "...")
+            *)
+              E.apply_nolabs (E.lid "bind")
+                [ this # expr rhs;
+                  E.function_ "" None
+                    [ patt, this # expr next;
+                      P.var (Location.mkloc "_" Location.none),
+                      fail_code]]
+            | PossiblyExhaustive ->
+            (* We cannot determine whether pattern-matching against p can fail.
+               The desugaring is
+               
+               p <-- e1; e2    ~>    bind e1 (function p when true -> e2
+               | _ -> fail "...")
+
+               The 'when true' guard avoids the redundancy warning that would
+               otherwise be generated if the OCaml implementation discovered
+               that matching against p could not fail.
+            *)
+              E.apply_nolabs (E.lid "bind")
+                [ this # expr rhs;
+                  E.function_ "" None
+                    [ patt, (E.when_
+                               ~loc:Location.none
+                               (E.construct ~loc:Location.none 
+                                  (Location.mkloc (Longident.parse "true") Location.none)
+                                  None false)
+                               (this # expr next));
+                      P.var (Location.mkloc "_" Location.none),
+                      fail_code]]
+          )
 
       | Pexp_sequence (first, second) when in_monad ->
         E.apply_nolabs (E.lid "bind")


### PR DESCRIPTION
Support for patterns on the LHS of <--, e.g.

```
  perform
       ((x, y) <-- m;
        [| Some z |] <-- n;
        return (x + y *z))
```

If pattern matching fails then "fail" is called, as in Haskell, which allows backtracking in list-like monads, for example.

Care is taken to avoid generating code that has redundant tests, or that causes warnings.

Includes some examples involving pattern matching, and a larger example translated from Hutton & Meijer's "Monadic Parsing in Haskell".
